### PR TITLE
- GetProfileByKey depends on ICopernicaProfile instad of CopernicaPro…

### DIFF
--- a/Src/CopernicaNET/Copernica.cs
+++ b/Src/CopernicaNET/Copernica.cs
@@ -207,7 +207,7 @@ namespace Arlanet.CopernicaNET
         /// <typeparam name="T1"></typeparam>
         /// <param name="inputprofile"></param>
         /// <returns></returns>
-        public T GetProfileByKey<T>(T inputprofile) where T : CopernicaProfile, new()
+        public virtual T GetProfileByKey<T>(T inputprofile) where T : ICopernicaProfile, new()
         {
             //ValidateProfile<T>(inputprofile);
             //TODO: Zorgen dat er meer identifiers kunnen! + Toevoegen aan documentatie

--- a/Src/CopernicaNET/Data/CopernicaFieldTypes.cs
+++ b/Src/CopernicaNET/Data/CopernicaFieldTypes.cs
@@ -14,6 +14,7 @@
         public const string PhoneField = "phone";
         public const string PhoneFaxField = "phone_fax";
         public const string PhoneGsmField = "phone_gsm";
+		public const string SelectField = "select";
         public const string ForeignKeyField = "foreign_key";
     }
 }

--- a/Src/CopernicaNET/Helpers/Validator.cs
+++ b/Src/CopernicaNET/Helpers/Validator.cs
@@ -31,7 +31,7 @@ namespace Arlanet.CopernicaNET.Helpers
                 {
                     throw new CopernicaException(String.Format("The field '{0}' does not match with any field in the copernica database. Make sure the name and database ID are correct.", objectfield.Name));
                 }
-                if (copernicafield.Length != objectfield.Length && copernicafield.Length != 0 && copernicafield.Length != 0)
+				if ((copernicafield.Type == CopernicaFieldTypes.EmailField || copernicafield.Type == CopernicaFieldTypes.TextField || copernicafield.Type == CopernicaFieldTypes.LargeTextField) && copernicafield.Length != objectfield.Length && copernicafield.Length != 0 && copernicafield.Length != 0)
                 {
                     throw new CopernicaException(String.Format("Field length mismatch on '{0}', the length is '{1}' and should be '{2}'", objectfield.Name, objectfield.Length, copernicafield.Length));
                 }


### PR DESCRIPTION
- GetProfileByKey depends on ICopernicaProfile instad of CopernicaProfile so CopernicaConfigurableProfile can be used as parameter.
- Added missing CopernicaFieldType: SelectField.
- Changed Validation on field length so the length attribute is not required on DateField anymore.
